### PR TITLE
Allow pass down requestOptions and delay miniget stream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,11 @@ module.exports = function(playlistURL, options) {
   options = options || {};
   var chunkReadahead = options.chunkReadahead || 3;
   var refreshInterval = options.refreshInterval || 600000; // 10 minutes
+  var requestOptions = options.requestOptions;
 
   var latestSegment;
-  var streamQueue = new Queue(function(segment, callback) {
+  var streamQueue = new Queue(function(getSegment, callback) {
+    var segment = getSegment();
     latestSegment = segment;
     segment.pipe(stream, { end: false });
     segment.on('error', callback);
@@ -25,7 +27,10 @@ module.exports = function(playlistURL, options) {
   }, { concurrency: 1 });
 
   var requestQueue = new Queue(function(segmentURL, callback) {
-    streamQueue.push(miniget(urlResolve(playlistURL, segmentURL)), callback);
+    streamQueue.push(
+      function() { return miniget(urlResolve(playlistURL, segmentURL), requestOptions); },
+      callback
+    );
   }, {
     concurrency: chunkReadahead,
     unique: function(segmentURL) { return segmentURL; },
@@ -57,7 +62,7 @@ module.exports = function(playlistURL, options) {
   function refreshPlaylist() {
     clearTimeout(tid);
     fetchingPlaylist = true;
-    var req = miniget(playlistURL);
+    var req = miniget(playlistURL, requestOptions);
     req.on('error', onError);
     var parser = req.pipe(new m3u8());
     parser.on('tag', function(tagName) {


### PR DESCRIPTION
1. Allow pass down requestOptions #2 
2. When `streamQueue.push` miniget stream, miniget start load immediately, if error occurs before `Queue` worker callback, it will cause no error listenner error and node exit.
