### PR TITLE
fix: stop requiring url & make webpack possible again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { PassThrough } from 'stream';
-import { resolve as urlResolve } from 'url';
 import miniget from 'miniget';
 import m3u8Parser from './m3u8-parser';
 import DashMPDParser from './dash-mpd-parser';
@@ -89,7 +88,7 @@ let m3u8stream = ((playlistURL: string, options: m3u8stream.Options = {}): m3u8s
         Range: `bytes=${segment.range.start}-${segment.range.end}`,
       });
     }
-    let req = miniget(urlResolve(playlistURL, segment.url), reqOptions);
+    let req = miniget(new URL(segment.url, playlistURL), reqOptions);
     req.on('error', callback);
     forwardEvents(req);
     streamQueue.push(req, (_, size) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ let m3u8stream = ((playlistURL: string, options: m3u8stream.Options = {}): m3u8s
         Range: `bytes=${segment.range.start}-${segment.range.end}`,
       });
     }
-    let req = miniget(new URL(segment.url, playlistURL), reqOptions);
+    let req = miniget(new URL(segment.url, playlistURL).toString(), reqOptions);
     req.on('error', callback);
     forwardEvents(req);
     streamQueue.push(req, (_, size) => {


### PR DESCRIPTION
Replaces: https://github.com/fent/node-m3u8stream/pull/88
Original Issue: https://github.com/fent/node-ytdl-core/issues/882